### PR TITLE
Fix: Tests broken with foreign key in windows env

### DIFF
--- a/models/boil_queries_test.go
+++ b/models/boil_queries_test.go
@@ -23,7 +23,7 @@ func MustTx(transactor boil.Transactor, err error) boil.Transactor {
 	return transactor
 }
 
-var rgxPGFkey = regexp.MustCompile(`(?m)^ALTER TABLE ONLY .*\n\s+ADD CONSTRAINT .*? FOREIGN KEY .*?;\n`)
+var rgxPGFkey = regexp.MustCompile(`(?m)^ALTER TABLE ONLY .*\n\s+ADD CONSTRAINT .*? FOREIGN KEY .*?;`)
 var rgxMySQLkey = regexp.MustCompile(`(?m)((,\n)?\s+CONSTRAINT.*?FOREIGN KEY.*?\n)+`)
 var rgxMSSQLkey = regexp.MustCompile(`(?m)^ALTER TABLE .*ADD\s+CONSTRAINT .* FOREIGN KEY.*?.*\n?REFERENCES.*`)
 


### PR DESCRIPTION
In windows environmet all sqlboiler generetad tests failed - removing \n fixed as described in this resource:
https://github.com/volatiletech/sqlboiler/issues/173
Please check that after commit tests continue to work as expected in unix environment.
Of course tested in windows and now all tests success.